### PR TITLE
small bug modalRecipe declared and defined twice commented out 97

### DIFF
--- a/assets/javascript/edamam.js
+++ b/assets/javascript/edamam.js
@@ -93,7 +93,8 @@ $(document).ready(function () {
 
                 $("#recipeCards").append(showDiv);
 
-                let modalRecipe = response.hits[i].recipe.ingredients;                
+                //commented out 97- djj
+                //let modalRecipe = response.hits[i].recipe.ingredients;                
 
                 console.log(modalRecipe);
 


### PR DESCRIPTION
Small bug.  Recipe cards weren't showing.  Just commented out line 97.